### PR TITLE
Add "Day After Thanksgiving" (Black Friday)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ bower_components/
 composer.lock
 vendor
 index.php
+.phpunit.result.cache
 
 ## MAC STUFF
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ This extends [Carbon](http://carbon.nesbot.com/) and adds support for several US
 * St. Patrick's Day
 * Tax Day
 * Thanksgiving
+* Black Friday
 * Valentine's Day
 * Veterans Day
 
@@ -107,6 +108,7 @@ $carbon->getHalloweenDayHoliday();              // 2018-10-31 00:00:00
 $carbon->getDaylightSavingEndHoliday();         // 2018-11-04 00:00:00
 $carbon->getVeteransDayHoliday();               // 2018-11-11 00:00:00
 $carbon->getThanksgivingHoliday();              // 2018-11-22 00:00:00
+$carbon->getBlackFridayHoliday();               // 2018-11-23 00:00:00
 $carbon->getPearlHarborRemembranceHoliday();    // 2018-12-07 00:00:00
 $carbon->getChristmasEveHoliday();              // 2018-12-24 00:00:00
 $carbon->getChristmasDayHoliday();              // 2018-12-25 00:00:00
@@ -152,8 +154,11 @@ $carbon->getHolidayName(); // Christmas Day (Observed)
 
 1. Clone the repo and install dependencies.
 
-        composer install
+```
+composer install
+```
 
 2. Run the test suite.
-
-        ./vendor/bin/phpunit
+```
+./vendor/bin/phpunit
+```

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ $carbon = Carbon::create(2016, 12, 26); // Monday
 $carbon->isBankHoliday(); // bool (true)
 ```
 
-### Additional Examples    
+### Additional Examples
 ```php
 $carbon = new Carbon();
 $carbon = Carbon::create(2018, 01, 01);
@@ -147,3 +147,13 @@ $carbon = new Carbon();
 $carbon = Carbon::create(2016, 12, 26); // Monday
 $carbon->getHolidayName(); // Christmas Day (Observed)
 ```
+
+### Contributing
+
+1. Clone the repo and install dependencies.
+
+        composer install
+
+2. Run the test suite.
+
+        ./vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -10,5 +10,8 @@
         "psr-4": {
             "USHolidays\\": "src/"
         }
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^8.4"
     }
 }

--- a/dates.txt
+++ b/dates.txt
@@ -7,13 +7,13 @@ Presidents' Day                 <!-- 3rd Monday of February -->
 Daylight Saving (Start)         <!-- 2nd Sunday of March -->
 St. Patrick's Day               <!-- 03/17 -->
 April Fool's Day                <!-- 04/01 -->
-Tax Day 			            <!-- 04/15 --> Notes: https://en.wikipedia.org/wiki/Tax_Day
-Earth Day			            <!-- 04/22 -->
-Cinco de Mayo     		        <!-- 05/05 -->
+Tax Day                         <!-- 04/15 --> Notes: https://en.wikipedia.org/wiki/Tax_Day
+Earth Day                       <!-- 04/22 -->
+Cinco de Mayo                   <!-- 05/05 -->
 Mother's Day                    <!-- 2nd Sunday of May -->
 Memorial Day                    <!-- Last Monday of May -->
 Armed Forces Day                <!-- 3rd Saturday of May -->
-Juneteenth			            <!-- 06/19 -->
+Juneteenth                      <!-- 06/19 -->
 Father's Day                    <!-- 3rd Sunday of June -->
 Flag Day                        <!-- 06/14 -->
 Independence Day                <!-- 07/04 -->
@@ -25,11 +25,12 @@ Halloween                       <!-- 10/31 -->
 Daylight Saving (End)           <!-- 1st Sunday of November -->
 Veterans Day                    <!-- 11/11 -->
 Thanksgiving                    <!-- 4th Thursday of November -->
+Day After Thanksgiving          <!-- Friday after Thanksgiving (Black Friday) -->
 Pearl Harbor Remembrance Day    <!-- 12/07 -->
 Christmas Eve                   <!-- 12/25 -->
 Christmas Day                   <!-- 12/25 -->
-Kwanzaa				            <!-- 12/26 -->
-New Year's Eve		            <!-- 12/31 -->
+Kwanzaa                         <!-- 12/26 -->
+New Year's Eve                  <!-- 12/31 -->
 
 
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false">
+
+    <testsuites>
+        <testsuite name="Carbon Holidays Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory suffix=".php">src/</directory>
+        </whitelist>
+    </filter>
+
+    <php>
+        <env name="APP_ENV" value="testing"/>
+    </php>
+
+</phpunit>

--- a/src/Carbon.php
+++ b/src/Carbon.php
@@ -1,44 +1,40 @@
-<?php
+<?php namespace USHolidays;
 
-namespace USHolidays;
+class Carbon extends \Carbon\Carbon {
 
-class Carbon extends \Carbon\Carbon
-{
-
-    private function getHolidays($year = null)
-    {
-        if ($year === null) {
+    private function getHolidays( $year = null ) {
+        if( $year === null) {
             $year = date('Y');
         }
 
         // Martin Luther King Jr. Day
         $martinLuther = Carbon::create($year, 1, 1);
-        if ($martinLuther->dayOfWeek !== Carbon::MONDAY) {
+        if( $martinLuther->dayOfWeek !== Carbon::MONDAY ) {
             $martinLuther->next(Carbon::MONDAY);
         }
         $martinLuther->next(Carbon::MONDAY)->next(Carbon::MONDAY);
 
         // Presidents' Day
         $presidents = Carbon::create($year, 2, 1);
-        if ($presidents->dayOfWeek !== Carbon::MONDAY) {
+        if( $presidents->dayOfWeek !== Carbon::MONDAY ) {
             $presidents->next(Carbon::MONDAY);
         }
         $presidents->next(Carbon::MONDAY)->next(Carbon::MONDAY);
 
         // Tax Day
         $taxDay = Carbon::create($year, 04, 15);
-        if ($taxDay->dayOfWeek === Carbon::SATURDAY || $taxDay->dayOfWeek === Carbon::SUNDAY) {
+        if( $taxDay->dayOfWeek === Carbon::SATURDAY || $taxDay->dayOfWeek === Carbon::SUNDAY ) {
             $taxDay->next(Carbon::TUESDAY);
-        } else if ($taxDay->dayOfWeek === Carbon::FRIDAY) {
+        } else if( $taxDay->dayOfWeek === Carbon::FRIDAY) {
             $taxDay->next(Carbon::MONDAY);
         }
 
         // Memorial Day
         $memorial = Carbon::create($year, 5, 1);
-        for ($i = 0; $i < 7; $i++) {
-            if ($memorial->month == 5) {
+        for ($i=0; $i < 7; $i++) {
+            if( $memorial->month == 5 ) {
                 $memorial->next(Carbon::MONDAY);
-            } else {
+            }  else {
                 $memorial->subDays(7);
                 break;
             }
@@ -46,13 +42,13 @@ class Carbon extends \Carbon\Carbon
 
         // Labor Day
         $labor = Carbon::create($year, 9, 1);
-        if ($labor->dayOfWeek !== Carbon::MONDAY) {
+        if( $labor->dayOfWeek !== Carbon::MONDAY ) {
             $labor->next(Carbon::MONDAY);
         }
 
         // Columbus Day
         $columbus = Carbon::create($year, 10, 1);
-        if ($columbus->dayOfWeek !== Carbon::MONDAY) {
+        if( $columbus->dayOfWeek !== Carbon::MONDAY ) {
             $columbus->next(Carbon::MONDAY);
         }
         $columbus->next(Carbon::MONDAY);
@@ -60,43 +56,46 @@ class Carbon extends \Carbon\Carbon
 
         // Thanksgiving
         $thanksgiving = Carbon::create($year, 11, 1);
-        if ($thanksgiving->dayOfWeek !== Carbon::THURSDAY) {
+        if( $thanksgiving->dayOfWeek !== Carbon::THURSDAY ) {
             $thanksgiving->next(Carbon::THURSDAY);
         }
         $thanksgiving->next(Carbon::THURSDAY)->next(Carbon::THURSDAY)->next(Carbon::THURSDAY);
 
 
+        // Day After Thanksgiving (Black Friday)
+        $dayAfterThanksgiving = $thanksgiving->copy()->addDay();
+
         // Daylight Saving (Start)
         $daylightStart = Carbon::create($year, 3, 1);
-        if ($daylightStart->dayOfWeek !== Carbon::SUNDAY) {
+        if( $daylightStart->dayOfWeek !== Carbon::SUNDAY ) {
             $daylightStart->next(Carbon::SUNDAY);
         }
         $daylightStart->next(Carbon::SUNDAY);
 
         // Mothers Day
         $mothers = Carbon::create($year, 5, 1);
-        if ($mothers->dayOfWeek !== Carbon::SUNDAY) {
+        if( $mothers->dayOfWeek !== Carbon::SUNDAY ) {
             $mothers->next(Carbon::SUNDAY);
         }
         $mothers->next(Carbon::SUNDAY);
 
         // Armed Forces Day
         $armed = Carbon::create($year, 5, 1);
-        if ($armed->dayOfWeek !== Carbon::SATURDAY) {
+        if( $armed->dayOfWeek !== Carbon::SATURDAY ) {
             $armed->next(Carbon::SATURDAY);
         }
         $armed->next(Carbon::SATURDAY)->next(Carbon::SATURDAY);
 
         // Father Day
         $father = Carbon::create($year, 6, 1);
-        if ($father->dayOfWeek !== Carbon::SUNDAY) {
+        if( $father->dayOfWeek !== Carbon::SUNDAY ) {
             $father->next(Carbon::SUNDAY);
         }
         $father->next(Carbon::SUNDAY)->next(Carbon::SUNDAY);
 
         // Daylight Saving (End)
         $daylightEnd = Carbon::create($year, 11, 1);
-        if ($daylightEnd->dayOfWeek !== Carbon::SUNDAY) {
+        if( $daylightEnd->dayOfWeek !== Carbon::SUNDAY ) {
             $daylightEnd->next(Carbon::SUNDAY);
         }
 
@@ -288,6 +287,12 @@ class Carbon extends \Carbon\Carbon
                 'bank_holiday' => false,
                 'id' => 31
             ),
+            array(
+                'name' => "Day After Thanksgiving",
+                'date' => $dayAfterThanksgiving,
+                'bank_holiday' => false,
+                'id' => 32
+            ),
         );
 
 
@@ -301,7 +306,7 @@ class Carbon extends \Carbon\Carbon
         $isHoliday = false;
 
         foreach ($holidays as $holiday) {
-            if ($this->isBirthday($holiday['date'])) {
+            if( $this->isBirthday($holiday['date']) ) {
                 $isHoliday = true;
             }
         }
@@ -316,23 +321,24 @@ class Carbon extends \Carbon\Carbon
         $isBankHoliday = false;
 
         foreach ($holidays as $holiday) {
-            if ($this->isBirthday($holiday['date']) && $holiday['bank_holiday']) {
-                if ($this->dayOfWeek !== Carbon::SUNDAY && $this->dayOfWeek !== Carbon::SATURDAY) {
+            if( $this->isBirthday($holiday['date']) && $holiday['bank_holiday'] ) {
+                if($this->dayOfWeek !== Carbon::SUNDAY && $this->dayOfWeek !== Carbon::SATURDAY) {
                     $isBankHoliday = true;
                 }
+
             } else {
-                if ($this->dayOfWeek === Carbon::MONDAY) {
+                if( $this->dayOfWeek === Carbon::MONDAY ) {
                     $this->subDay();
 
-                    if ($this->isBirthday($holiday['date']) && $holiday['bank_holiday']) {
+                    if( $this->isBirthday($holiday['date']) && $holiday['bank_holiday'] ) {
                         $isBankHoliday = true;
                     } else {
                         $this->addDay();
                     }
-                } else if ($this->dayOfWeek === Carbon::FRIDAY) {
+                } else if( $this->dayOfWeek === Carbon::FRIDAY ) {
                     $this->addDay();
 
-                    if ($this->isBirthday($holiday['date']) && $holiday['bank_holiday']) {
+                    if( $this->isBirthday($holiday['date']) && $holiday['bank_holiday'] ) {
                         $isBankHoliday = true;
                     } else {
                         $this->subDay();
@@ -351,21 +357,21 @@ class Carbon extends \Carbon\Carbon
         $holidayName = false;
 
         foreach ($holidays as $holiday) {
-            if ($this->isBirthday($holiday['date'])) {
+            if( $this->isBirthday($holiday['date']) ) {
                 $holidayName = $holiday['name'];
             } else {
-                if ($this->dayOfWeek === Carbon::MONDAY) {
+                if( $this->dayOfWeek === Carbon::MONDAY ) {
                     $this->subDay();
 
-                    if ($this->isBirthday($holiday['date']) && $holiday['bank_holiday']) {
+                    if( $this->isBirthday($holiday['date']) && $holiday['bank_holiday'] ) {
                         $holidayName = $holiday['name'] . ' (Observed)';
                     } else {
                         $this->addDay();
                     }
-                } else if ($this->dayOfWeek === Carbon::FRIDAY) {
+                } else if( $this->dayOfWeek === Carbon::FRIDAY ) {
                     $this->addDay();
 
-                    if ($this->isBirthday($holiday['date']) && $holiday['bank_holiday']) {
+                    if( $this->isBirthday($holiday['date']) && $holiday['bank_holiday'] ) {
                         $holidayName = $holiday['name'] . ' (Observed)';
                     } else {
                         $this->subDay();
@@ -383,7 +389,7 @@ class Carbon extends \Carbon\Carbon
         $year = $year ? $year : $this->year;
         $holidays = $this->getHolidays($year);
 
-        $index = array_search($id, array_column($holidays, 'id'));
+        $index = array_search($id, array_column($holidays, 'id') );
         $date = $holidays[$index]['date'];
 
         $this->modify($date);
@@ -544,5 +550,10 @@ class Carbon extends \Carbon\Carbon
     public function getTaxDayHoliday($year = null)
     {
         return $this->getHoldiayById(31, $year);
+    }
+
+    public function getDayAfterThanksgivingHoliday($year = null)
+    {
+        return $this->getHolidayById(32, $year);
     }
 }

--- a/src/Carbon.php
+++ b/src/Carbon.php
@@ -384,7 +384,7 @@ class Carbon extends \Carbon\Carbon {
     }
 
 
-    private function getHoldiayById($id, $year)
+    private function getHolidayById($id, $year)
     {
         $year = $year ? $year : $this->year;
         $holidays = $this->getHolidays($year);
@@ -399,157 +399,157 @@ class Carbon extends \Carbon\Carbon {
 
     public function getNewYearsDayHoliday($year = null)
     {
-        return $this->getHoldiayById(1, $year);
+        return $this->getHolidayById(1, $year);
     }
 
     public function getMLKDayHoliday($year = null)
     {
-        return $this->getHoldiayById(2, $year);
+        return $this->getHolidayById(2, $year);
     }
 
     public function getGroundhogDayHoliday($year = null)
     {
-        return $this->getHoldiayById(3, $year);
+        return $this->getHolidayById(3, $year);
     }
 
     public function getValentinesDayHoliday($year = null)
     {
-        return $this->getHoldiayById(4, $year);
+        return $this->getHolidayById(4, $year);
     }
 
     public function getPresidentsDayHoliday($year = null)
     {
-        return $this->getHoldiayById(5, $year);
+        return $this->getHolidayById(5, $year);
     }
 
     public function getDaylightSavingStartHoliday($year = null)
     {
-        return $this->getHoldiayById(6, $year);
+        return $this->getHolidayById(6, $year);
     }
 
     public function getStPatricksDayHoliday($year = null)
     {
-        return $this->getHoldiayById(7, $year);
+        return $this->getHolidayById(7, $year);
     }
 
     public function getAprilFoolsDayHoliday($year = null)
     {
-        return $this->getHoldiayById(8, $year);
+        return $this->getHolidayById(8, $year);
     }
 
     public function getMothersDayHoliday($year = null)
     {
-        return $this->getHoldiayById(9, $year);
+        return $this->getHolidayById(9, $year);
     }
 
     public function getMemorialDayHoliday($year = null)
     {
-        return $this->getHoldiayById(10, $year);
+        return $this->getHolidayById(10, $year);
     }
 
     public function getArmedForcesDayHoliday($year = null)
     {
-        return $this->getHoldiayById(11, $year);
+        return $this->getHolidayById(11, $year);
     }
 
     public function getFathersDayHoliday($year = null)
     {
-        return $this->getHoldiayById(12, $year);
+        return $this->getHolidayById(12, $year);
     }
 
     public function getFlagsDayHoliday($year = null)
     {
-        return $this->getHoldiayById(13, $year);
+        return $this->getHolidayById(13, $year);
     }
 
     public function getIndependenceDayHoliday($year = null)
     {
-        return $this->getHoldiayById(14, $year);
+        return $this->getHolidayById(14, $year);
     }
 
     public function getLaborDayHoliday($year = null)
     {
-        return $this->getHoldiayById(15, $year);
+        return $this->getHolidayById(15, $year);
     }
 
     public function getPatriotsDayHoliday($year = null)
     {
-        return $this->getHoldiayById(16, $year);
+        return $this->getHolidayById(16, $year);
     }
 
     public function getColumbusDayHoliday($year = null)
     {
-        return $this->getHoldiayById(17, $year);
+        return $this->getHolidayById(17, $year);
     }
 
     public function getHalloweenDayHoliday($year = null)
     {
-        return $this->getHoldiayById(18, $year);
+        return $this->getHolidayById(18, $year);
     }
 
     public function getDaylightSavingEndHoliday($year = null)
     {
-        return $this->getHoldiayById(19, $year);
+        return $this->getHolidayById(19, $year);
     }
 
     public function getVeteransDayHoliday($year = null)
     {
-        return $this->getHoldiayById(20, $year);
+        return $this->getHolidayById(20, $year);
     }
 
     public function getThanksgivingHoliday($year = null)
     {
-        return $this->getHoldiayById(21, $year);
+        return $this->getHolidayById(21, $year);
     }
 
     public function getPearlHarborRemembranceHoliday($year = null)
     {
-        return $this->getHoldiayById(22, $year);
+        return $this->getHolidayById(22, $year);
     }
 
     public function getChristmasEveHoliday($year = null)
     {
-        return $this->getHoldiayById(23, $year);
+        return $this->getHolidayById(23, $year);
     }
 
     public function getChristmasDayHoliday($year = null)
     {
-        return $this->getHoldiayById(24, $year);
+        return $this->getHolidayById(24, $year);
     }
 
     public function getNewYearsEveHoliday($year = null)
     {
-        return $this->getHoldiayById(25, $year);
+        return $this->getHolidayById(25, $year);
     }
 
     public function getKwanzaaHoliday($year = null)
     {
-        return $this->getHoldiayById(26, $year);
+        return $this->getHolidayById(26, $year);
     }
 
     public function getEarthDayHoliday($year = null)
     {
-        return $this->getHoldiayById(27, $year);
+        return $this->getHolidayById(27, $year);
     }
 
     public function getCincoDeMayoHoliday($year = null)
     {
-        return $this->getHoldiayById(28, $year);
+        return $this->getHolidayById(28, $year);
     }
 
     public function getJuneteenthHoliday($year = null)
     {
-        return $this->getHoldiayById(29, $year);
+        return $this->getHolidayById(29, $year);
     }
 
     public function getIndigenousPeoplesDayHoliday($year = null)
     {
-        return $this->getHoldiayById(30, $year);
+        return $this->getHolidayById(30, $year);
     }
 
     public function getTaxDayHoliday($year = null)
     {
-        return $this->getHoldiayById(31, $year);
+        return $this->getHolidayById(31, $year);
     }
 
     public function getDayAfterThanksgivingHoliday($year = null)

--- a/src/Carbon.php
+++ b/src/Carbon.php
@@ -1,110 +1,114 @@
-<?php namespace USHolidays;
+<?php
 
-class Carbon extends \Carbon\Carbon {
+namespace USHolidays;
 
-    private function getHolidays( $year = null ) {
-        if( $year === null) {
+class Carbon extends \Carbon\Carbon
+{
+
+    private function getHolidays($year = null)
+    {
+        if ($year === null) {
             $year = date('Y');
         }
 
         // Martin Luther King Jr. Day
         $martinLuther = Carbon::create($year, 1, 1);
-        if( $martinLuther->dayOfWeek !== Carbon::MONDAY ) {
-        	$martinLuther->next(Carbon::MONDAY);
+        if ($martinLuther->dayOfWeek !== Carbon::MONDAY) {
+            $martinLuther->next(Carbon::MONDAY);
         }
         $martinLuther->next(Carbon::MONDAY)->next(Carbon::MONDAY);
 
         // Presidents' Day
         $presidents = Carbon::create($year, 2, 1);
-        if( $presidents->dayOfWeek !== Carbon::MONDAY ) {
-        	$presidents->next(Carbon::MONDAY);
+        if ($presidents->dayOfWeek !== Carbon::MONDAY) {
+            $presidents->next(Carbon::MONDAY);
         }
         $presidents->next(Carbon::MONDAY)->next(Carbon::MONDAY);
 
         // Tax Day
         $taxDay = Carbon::create($year, 04, 15);
-        if( $taxDay->dayOfWeek === Carbon::SATURDAY || $taxDay->dayOfWeek === Carbon::SUNDAY ) {
-        	$taxDay->next(Carbon::TUESDAY);
-        } else if( $taxDay->dayOfWeek === Carbon::FRIDAY) {
-        	$taxDay->next(Carbon::MONDAY);
+        if ($taxDay->dayOfWeek === Carbon::SATURDAY || $taxDay->dayOfWeek === Carbon::SUNDAY) {
+            $taxDay->next(Carbon::TUESDAY);
+        } else if ($taxDay->dayOfWeek === Carbon::FRIDAY) {
+            $taxDay->next(Carbon::MONDAY);
         }
 
         // Memorial Day
         $memorial = Carbon::create($year, 5, 1);
-        for ($i=0; $i < 7; $i++) {
-        	if( $memorial->month == 5 ) {
-        		$memorial->next(Carbon::MONDAY);
-        	}  else {
-        		$memorial->subDays(7);
-        		break;
-        	}
+        for ($i = 0; $i < 7; $i++) {
+            if ($memorial->month == 5) {
+                $memorial->next(Carbon::MONDAY);
+            } else {
+                $memorial->subDays(7);
+                break;
+            }
         }
 
         // Labor Day
         $labor = Carbon::create($year, 9, 1);
-        if( $labor->dayOfWeek !== Carbon::MONDAY ) {
-        	$labor->next(Carbon::MONDAY);
+        if ($labor->dayOfWeek !== Carbon::MONDAY) {
+            $labor->next(Carbon::MONDAY);
         }
 
         // Columbus Day
         $columbus = Carbon::create($year, 10, 1);
-        if( $columbus->dayOfWeek !== Carbon::MONDAY ) {
-        	$columbus->next(Carbon::MONDAY);
+        if ($columbus->dayOfWeek !== Carbon::MONDAY) {
+            $columbus->next(Carbon::MONDAY);
         }
         $columbus->next(Carbon::MONDAY);
 
 
         // Thanksgiving
         $thanksgiving = Carbon::create($year, 11, 1);
-        if( $thanksgiving->dayOfWeek !== Carbon::THURSDAY ) {
-        	$thanksgiving->next(Carbon::THURSDAY);
+        if ($thanksgiving->dayOfWeek !== Carbon::THURSDAY) {
+            $thanksgiving->next(Carbon::THURSDAY);
         }
         $thanksgiving->next(Carbon::THURSDAY)->next(Carbon::THURSDAY)->next(Carbon::THURSDAY);
 
 
         // Daylight Saving (Start)
         $daylightStart = Carbon::create($year, 3, 1);
-        if( $daylightStart->dayOfWeek !== Carbon::SUNDAY ) {
-        	$daylightStart->next(Carbon::SUNDAY);
+        if ($daylightStart->dayOfWeek !== Carbon::SUNDAY) {
+            $daylightStart->next(Carbon::SUNDAY);
         }
         $daylightStart->next(Carbon::SUNDAY);
 
         // Mothers Day
         $mothers = Carbon::create($year, 5, 1);
-        if( $mothers->dayOfWeek !== Carbon::SUNDAY ) {
-        	$mothers->next(Carbon::SUNDAY);
+        if ($mothers->dayOfWeek !== Carbon::SUNDAY) {
+            $mothers->next(Carbon::SUNDAY);
         }
         $mothers->next(Carbon::SUNDAY);
 
         // Armed Forces Day
         $armed = Carbon::create($year, 5, 1);
-        if( $armed->dayOfWeek !== Carbon::SATURDAY ) {
+        if ($armed->dayOfWeek !== Carbon::SATURDAY) {
             $armed->next(Carbon::SATURDAY);
         }
         $armed->next(Carbon::SATURDAY)->next(Carbon::SATURDAY);
 
         // Father Day
         $father = Carbon::create($year, 6, 1);
-        if( $father->dayOfWeek !== Carbon::SUNDAY ) {
-        	$father->next(Carbon::SUNDAY);
+        if ($father->dayOfWeek !== Carbon::SUNDAY) {
+            $father->next(Carbon::SUNDAY);
         }
         $father->next(Carbon::SUNDAY)->next(Carbon::SUNDAY);
 
         // Daylight Saving (End)
         $daylightEnd = Carbon::create($year, 11, 1);
-        if( $daylightEnd->dayOfWeek !== Carbon::SUNDAY ) {
-        	$daylightEnd->next(Carbon::SUNDAY);
+        if ($daylightEnd->dayOfWeek !== Carbon::SUNDAY) {
+            $daylightEnd->next(Carbon::SUNDAY);
         }
 
 
         $holidays = array(
-        	array(
+            array(
                 'name' => "New Year's Day",
                 'date' => Carbon::create($year, 1, 1),
                 'bank_holiday' => true,
                 'id' => 1
             ),
-        	array(
+            array(
                 'name' => "Martin Luther King Jr. Day",
                 'date' => $martinLuther,
                 'bank_holiday' => true,
@@ -122,7 +126,7 @@ class Carbon extends \Carbon\Carbon {
                 'bank_holiday' => false,
                 'id' => 4
             ),
-        	array(
+            array(
                 'name' => "Presidents' Day",
                 'date' => $presidents,
                 'bank_holiday' => true,
@@ -152,7 +156,7 @@ class Carbon extends \Carbon\Carbon {
                 'bank_holiday' => false,
                 'id' => 9
             ),
-        	array(
+            array(
                 'name' => "Memorial Day",
                 'date' => $memorial,
                 'bank_holiday' => true,
@@ -194,13 +198,13 @@ class Carbon extends \Carbon\Carbon {
                 'bank_holiday' => false,
                 'id' => 16
             ),
-        	array(
+            array(
                 'name' => "Columbus Day",
                 'date' => $columbus,
                 'bank_holiday' => true,
                 'id' => 17
             ),
-        	array(
+            array(
                 'name' => "Halloween",
                 'date' => Carbon::create($year, 10, 31),
                 'bank_holiday' => false,
@@ -236,7 +240,7 @@ class Carbon extends \Carbon\Carbon {
                 'bank_holiday' => false,
                 'id' => 23
             ),
-        	array(
+            array(
                 'name' => "Christmas Day",
                 'date' => Carbon::create($year, 12, 25),
                 'bank_holiday' => true,
@@ -291,13 +295,13 @@ class Carbon extends \Carbon\Carbon {
     }
 
     public function isHoliday($year = null)
-	{
+    {
         $year = $year ? $year : $this->year;
         $holidays = $this->getHolidays($year);
         $isHoliday = false;
 
         foreach ($holidays as $holiday) {
-            if( $this->isBirthday($holiday['date']) ) {
+            if ($this->isBirthday($holiday['date'])) {
                 $isHoliday = true;
             }
         }
@@ -306,30 +310,29 @@ class Carbon extends \Carbon\Carbon {
     }
 
     public function isBankHoliday($year = null)
-	{
+    {
         $year = $year ? $year : $this->year;
         $holidays = $this->getHolidays($year);
         $isBankHoliday = false;
 
         foreach ($holidays as $holiday) {
-            if( $this->isBirthday($holiday['date']) && $holiday['bank_holiday'] ) {
-                if($this->dayOfWeek !== Carbon::SUNDAY && $this->dayOfWeek !== Carbon::SATURDAY) {
+            if ($this->isBirthday($holiday['date']) && $holiday['bank_holiday']) {
+                if ($this->dayOfWeek !== Carbon::SUNDAY && $this->dayOfWeek !== Carbon::SATURDAY) {
                     $isBankHoliday = true;
                 }
-
             } else {
-                if( $this->dayOfWeek === Carbon::MONDAY ) {
+                if ($this->dayOfWeek === Carbon::MONDAY) {
                     $this->subDay();
 
-                    if( $this->isBirthday($holiday['date']) && $holiday['bank_holiday'] ) {
+                    if ($this->isBirthday($holiday['date']) && $holiday['bank_holiday']) {
                         $isBankHoliday = true;
                     } else {
                         $this->addDay();
                     }
-                } else if( $this->dayOfWeek === Carbon::FRIDAY ) {
+                } else if ($this->dayOfWeek === Carbon::FRIDAY) {
                     $this->addDay();
 
-                    if( $this->isBirthday($holiday['date']) && $holiday['bank_holiday'] ) {
+                    if ($this->isBirthday($holiday['date']) && $holiday['bank_holiday']) {
                         $isBankHoliday = true;
                     } else {
                         $this->subDay();
@@ -348,21 +351,21 @@ class Carbon extends \Carbon\Carbon {
         $holidayName = false;
 
         foreach ($holidays as $holiday) {
-            if( $this->isBirthday($holiday['date']) ) {
+            if ($this->isBirthday($holiday['date'])) {
                 $holidayName = $holiday['name'];
             } else {
-                if( $this->dayOfWeek === Carbon::MONDAY ) {
+                if ($this->dayOfWeek === Carbon::MONDAY) {
                     $this->subDay();
 
-                    if( $this->isBirthday($holiday['date']) && $holiday['bank_holiday'] ) {
+                    if ($this->isBirthday($holiday['date']) && $holiday['bank_holiday']) {
                         $holidayName = $holiday['name'] . ' (Observed)';
                     } else {
                         $this->addDay();
                     }
-                } else if( $this->dayOfWeek === Carbon::FRIDAY ) {
+                } else if ($this->dayOfWeek === Carbon::FRIDAY) {
                     $this->addDay();
 
-                    if( $this->isBirthday($holiday['date']) && $holiday['bank_holiday'] ) {
+                    if ($this->isBirthday($holiday['date']) && $holiday['bank_holiday']) {
                         $holidayName = $holiday['name'] . ' (Observed)';
                     } else {
                         $this->subDay();
@@ -380,7 +383,7 @@ class Carbon extends \Carbon\Carbon {
         $year = $year ? $year : $this->year;
         $holidays = $this->getHolidays($year);
 
-        $index = array_search($id, array_column($holidays, 'id') );
+        $index = array_search($id, array_column($holidays, 'id'));
         $date = $holidays[$index]['date'];
 
         $this->modify($date);

--- a/src/Carbon.php
+++ b/src/Carbon.php
@@ -32,7 +32,7 @@ class Carbon extends \Carbon\Carbon {
         // Memorial Day
         $memorial = Carbon::create($year, 5, 1);
         for ($i=0; $i < 7; $i++) {
-            if( $memorial->month == 5 ) {
+            if( $memorial->month === 5 ) {
                 $memorial->next(Carbon::MONDAY);
             }  else {
                 $memorial->subDays(7);
@@ -62,8 +62,8 @@ class Carbon extends \Carbon\Carbon {
         $thanksgiving->next(Carbon::THURSDAY)->next(Carbon::THURSDAY)->next(Carbon::THURSDAY);
 
 
-        // Day After Thanksgiving (Black Friday)
-        $dayAfterThanksgiving = $thanksgiving->copy()->addDay();
+        // Black Friday
+        $blackFriday = $thanksgiving->copy()->addDay();
 
         // Daylight Saving (Start)
         $daylightStart = Carbon::create($year, 3, 1);
@@ -288,8 +288,8 @@ class Carbon extends \Carbon\Carbon {
                 'id' => 31
             ),
             array(
-                'name' => "Day After Thanksgiving",
-                'date' => $dayAfterThanksgiving,
+                'name' => "Black Friday",
+                'date' => $blackFriday,
                 'bank_holiday' => false,
                 'id' => 32
             ),
@@ -357,27 +357,28 @@ class Carbon extends \Carbon\Carbon {
         $holidayName = false;
 
         foreach ($holidays as $holiday) {
-            if( $this->isBirthday($holiday['date']) ) {
-                $holidayName = $holiday['name'];
+            $dateToCheck = $this->copy();
+            if( $dateToCheck->isBirthday($holiday['date']) ) {
+                $holidayName .= $holiday['name'] . ', ';
             } else {
-                if( $this->dayOfWeek === Carbon::MONDAY ) {
-                    $this->subDay();
+                if( $dateToCheck->dayOfWeek === Carbon::MONDAY ) {
+                    $dateToCheck->subDay();
 
-                    if( $this->isBirthday($holiday['date']) && $holiday['bank_holiday'] ) {
-                        $holidayName = $holiday['name'] . ' (Observed)';
-                    } else {
-                        $this->addDay();
+                    if( $dateToCheck->isBirthday($holiday['date']) && $holiday['bank_holiday'] ) {
+                        $holidayName .= $holiday['name'] . ' (Observed), ';
                     }
-                } else if( $this->dayOfWeek === Carbon::FRIDAY ) {
-                    $this->addDay();
+                } else if( $dateToCheck->dayOfWeek === Carbon::FRIDAY ) {
+                    $dateToCheck->addDay();
 
-                    if( $this->isBirthday($holiday['date']) && $holiday['bank_holiday'] ) {
-                        $holidayName = $holiday['name'] . ' (Observed)';
-                    } else {
-                        $this->subDay();
+                    if( $dateToCheck->isBirthday($holiday['date']) && $holiday['bank_holiday'] ) {
+                        $holidayName .= $holiday['name'] . ' (Observed), ';
                     }
                 }
             }
+        }
+
+        if( $holidayName ) {
+            $holidayName = rtrim($holidayName, ', ');
         }
 
         return $holidayName;
@@ -552,7 +553,7 @@ class Carbon extends \Carbon\Carbon {
         return $this->getHolidayById(31, $year);
     }
 
-    public function getDayAfterThanksgivingHoliday($year = null)
+    public function getBlackFridayHoliday($year = null)
     {
         return $this->getHolidayById(32, $year);
     }

--- a/tests/CarbonTest.php
+++ b/tests/CarbonTest.php
@@ -1,0 +1,39 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use USHolidays\Carbon;
+
+class CarbonTest extends TestCase
+{
+    public function testThanksgiving()
+    {
+        $carbon = new Carbon();
+        $carbon = Carbon::create(2018, 1, 1);
+
+        $this->assertFalse(
+            $carbon->getThanksgivingHoliday()
+                ->isSameDay(Carbon::createFromDate(2018, 11, 21))
+        );
+
+        $this->assertTrue(
+            $carbon->getThanksgivingHoliday()
+                ->isSameDay(Carbon::createFromDate(2018, 11, 22))
+        );
+    }
+
+    public function testDayAfterThanksgiving()
+    {
+        $carbon = new Carbon();
+        $carbon = Carbon::create(2019, 1, 1);
+
+        $this->assertFalse(
+            $carbon->getDayAfterThanksgivingHoliday()
+                ->isSameDay(Carbon::createFromDate(2019, 11, 30))
+        );
+
+        $this->assertTrue(
+            $carbon->getDayAfterThanksgivingHoliday()
+                ->isSameDay(Carbon::createFromDate(2019, 11, 29))
+        );
+    }
+}

--- a/tests/CarbonTest.php
+++ b/tests/CarbonTest.php
@@ -5,6 +5,463 @@ use USHolidays\Carbon;
 
 class CarbonTest extends TestCase
 {
+    public function testNewYearsDay()
+    {
+        $carbon = new Carbon();
+        $carbon = Carbon::create(2018, 1, 1);
+
+        $this->assertFalse(
+            $carbon->getNewYearsDayHoliday()
+                ->isSameDay(Carbon::createFromDate(2018, 1, 2))
+        );
+
+        $this->assertTrue(
+            $carbon->getNewYearsDayHoliday()
+                ->isSameDay(Carbon::createFromDate(2018, 1, 1))
+        );
+    }
+
+    public function testMLKDay()
+    {
+        $carbon = new Carbon();
+        $carbon = Carbon::create(2018, 1, 1);
+
+        $this->assertFalse(
+            $carbon->getMLKDayHoliday()
+                ->isSameDay(Carbon::createFromDate(2018, 1, 16))
+        );
+
+        $this->assertTrue(
+            $carbon->getMLKDayHoliday()
+                ->isSameDay(Carbon::createFromDate(2018, 1, 15))
+        );
+    }
+
+    public function testGroundhogDay()
+    {
+        $carbon = new Carbon();
+        $carbon = Carbon::create(2018, 1, 1);
+
+        $this->assertFalse(
+            $carbon->getGroundhogDayHoliday()
+                ->isSameDay(Carbon::createFromDate(2018, 2, 3))
+        );
+
+        $this->assertTrue(
+            $carbon->getGroundhogDayHoliday()
+                ->isSameDay(Carbon::createFromDate(2018, 2, 2))
+        );
+    }
+
+    public function testValentinesDay()
+    {
+        $carbon = new Carbon();
+        $carbon = Carbon::create(2018, 1, 1);
+
+        $this->assertFalse(
+            $carbon->getValentinesDayHoliday()
+                ->isSameDay(Carbon::createFromDate(2018, 2, 13))
+        );
+
+        $this->assertTrue(
+            $carbon->getValentinesDayHoliday()
+                ->isSameDay(Carbon::createFromDate(2018, 2, 14))
+        );
+    }
+
+    public function testPresidentsDay()
+    {
+        $carbon = new Carbon();
+        $carbon = Carbon::create(2018, 1, 1);
+
+        $this->assertFalse(
+            $carbon->getPresidentsDayHoliday()
+                ->isSameDay(Carbon::createFromDate(2018, 2, 1))
+        );
+
+        $this->assertTrue(
+            $carbon->getPresidentsDayHoliday()
+                ->isSameDay(Carbon::createFromDate(2018, 2, 19))
+        );
+    }
+
+    public function testDaylightSavingStart()
+    {
+        $carbon = new Carbon();
+        $carbon = Carbon::create(2018, 1, 1);
+
+        $this->assertFalse(
+            $carbon->getDaylightSavingStartHoliday()
+                ->isSameDay(Carbon::createFromDate(2018, 3, 10))
+        );
+
+        $this->assertTrue(
+            $carbon->getDaylightSavingStartHoliday()
+                ->isSameDay(Carbon::createFromDate(2018, 3, 11))
+        );
+    }
+
+    public function testStPatricksDay()
+    {
+        $carbon = new Carbon();
+        $carbon = Carbon::create(2018, 1, 1);
+
+        $this->assertFalse(
+            $carbon->getStPatricksDayHoliday()
+                ->isSameDay(Carbon::createFromDate(2018, 3, 16))
+        );
+
+        $this->assertTrue(
+            $carbon->getStPatricksDayHoliday()
+                ->isSameDay(Carbon::createFromDate(2018, 3, 17))
+        );
+    }
+
+    public function testAprilFoolsDay()
+    {
+        $carbon = new Carbon();
+        $carbon = Carbon::create(2018, 1, 1);
+
+        $this->assertFalse(
+            $carbon->getAprilFoolsDayHoliday()
+                ->isSameDay(Carbon::createFromDate(2018, 4, 2))
+        );
+
+        $this->assertTrue(
+            $carbon->getAprilFoolsDayHoliday()
+                ->isSameDay(Carbon::createFromDate(2018, 4, 1))
+        );
+    }
+
+    public function testTaxDayHoliday()
+    {
+        $carbon = new Carbon();
+        $carbon = Carbon::create(2018, 1, 1);
+
+        $this->assertFalse(
+            $carbon->getTaxDayHoliday()
+                ->isSameDay(Carbon::createFromDate(2018, 4, 15))
+        );
+
+        $this->assertTrue(
+            $carbon->getTaxDayHoliday()
+                ->isSameDay(Carbon::createFromDate(2018, 4, 17))
+        );
+
+        $carbon = new Carbon();
+        $carbon = Carbon::create(2019, 1, 1);
+
+        $this->assertFalse(
+            $carbon->getTaxDayHoliday()
+                ->isSameDay(Carbon::createFromDate(2019, 4, 16))
+        );
+
+        $this->assertTrue(
+            $carbon->getTaxDayHoliday()
+                ->isSameDay(Carbon::createFromDate(2019, 4, 15))
+        );
+
+
+        $carbon = new Carbon();
+        $carbon = Carbon::create(2020, 1, 1);
+
+        $this->assertFalse(
+            $carbon->getTaxDayHoliday()
+                ->isSameDay(Carbon::createFromDate(2020, 4, 16))
+        );
+
+        $this->assertTrue(
+            $carbon->getTaxDayHoliday()
+                ->isSameDay(Carbon::createFromDate(2020, 4, 15))
+        );
+    }
+
+    public function testEarthDay()
+    {
+        $carbon = new Carbon();
+        $carbon = Carbon::create(2018, 1, 1);
+
+        $this->assertFalse(
+            $carbon->getEarthDayHoliday()
+                ->isSameDay(Carbon::createFromDate(2018, 4, 21))
+        );
+
+        $this->assertTrue(
+            $carbon->getEarthDayHoliday()
+                ->isSameDay(Carbon::createFromDate(2018, 4, 22))
+        );
+    }
+
+    public function testCincoDeMayo()
+    {
+        $carbon = new Carbon();
+        $carbon = Carbon::create(2018, 1, 1);
+
+        $this->assertFalse(
+            $carbon->getCincoDeMayoHoliday()
+                ->isSameDay(Carbon::createFromDate(2018, 5, 7))
+        );
+
+        $this->assertTrue(
+            $carbon->getCincoDeMayoHoliday()
+                ->isSameDay(Carbon::createFromDate(2018, 5, 5))
+        );
+    }
+
+    public function testMothersDay()
+    {
+        $carbon = new Carbon();
+        $carbon = Carbon::create(2018, 1, 1);
+
+        $this->assertFalse(
+            $carbon->getMothersDayHoliday()
+                ->isSameDay(Carbon::createFromDate(2018, 5, 12))
+        );
+
+        $this->assertTrue(
+            $carbon->getMothersDayHoliday()
+                ->isSameDay(Carbon::createFromDate(2018, 5, 13))
+        );
+    }
+
+    public function testArmedForcesDay()
+    {
+        $carbon = new Carbon();
+        $carbon = Carbon::create(2018, 1, 1);
+
+        $this->assertFalse(
+            $carbon->getArmedForcesDayHoliday()
+                ->isSameDay(Carbon::createFromDate(2018, 5, 18))
+        );
+
+        $this->assertTrue(
+            $carbon->getArmedForcesDayHoliday()
+                ->isSameDay(Carbon::createFromDate(2018, 5, 19))
+        );
+    }
+
+    public function testMemorialDay()
+    {
+        $carbon = new Carbon();
+        $carbon = Carbon::create(2018, 1, 1);
+
+        $this->assertFalse(
+            $carbon->getMemorialDayHoliday()
+                ->isSameDay(Carbon::createFromDate(2018, 5, 27))
+        );
+
+        $this->assertTrue(
+            $carbon->getMemorialDayHoliday()
+                ->isSameDay(Carbon::createFromDate(2018, 5, 28))
+        );
+
+        $carbon = new Carbon();
+        $carbon = Carbon::create(2019, 1, 1);
+
+        $this->assertFalse(
+            $carbon->getMemorialDayHoliday()
+                ->isSameDay(Carbon::createFromDate(2019, 5, 26))
+        );
+
+        $this->assertTrue(
+            $carbon->getMemorialDayHoliday()
+                ->isSameDay(Carbon::createFromDate(2019, 5, 27))
+        );
+
+        $carbon = new Carbon();
+        $carbon = Carbon::create(2020, 1, 1);
+
+        $this->assertFalse(
+            $carbon->getMemorialDayHoliday()
+                ->isSameDay(Carbon::createFromDate(2020, 5, 26))
+        );
+
+        $this->assertTrue(
+            $carbon->getMemorialDayHoliday()
+                ->isSameDay(Carbon::createFromDate(2020, 5, 25))
+        );
+    }
+
+    public function testFlagsDay()
+    {
+        $carbon = new Carbon();
+        $carbon = Carbon::create(2018, 1, 1);
+
+        $this->assertFalse(
+            $carbon->getFlagsDayHoliday()
+                ->isSameDay(Carbon::createFromDate(2018, 6, 13))
+        );
+
+        $this->assertTrue(
+            $carbon->getFlagsDayHoliday()
+                ->isSameDay(Carbon::createFromDate(2018, 6, 14))
+        );
+    }
+
+    public function testFathersDay()
+    {
+        $carbon = new Carbon();
+        $carbon = Carbon::create(2018, 1, 1);
+
+        $this->assertFalse(
+            $carbon->getFathersDayHoliday()
+                ->isSameDay(Carbon::createFromDate(2018, 6, 18))
+        );
+
+        $this->assertTrue(
+            $carbon->getFathersDayHoliday()
+                ->isSameDay(Carbon::createFromDate(2018, 6, 17))
+        );
+    }
+
+    public function testJuneteenth()
+    {
+        $carbon = new Carbon();
+        $carbon = Carbon::create(2018, 1, 1);
+
+        $this->assertFalse(
+            $carbon->getJuneteenthHoliday()
+                ->isSameDay(Carbon::createFromDate(2018, 6, 18))
+        );
+
+        $this->assertTrue(
+            $carbon->getJuneteenthHoliday()
+                ->isSameDay(Carbon::createFromDate(2018, 6, 19))
+        );
+    }
+
+    public function testIndependenceDay()
+    {
+        $carbon = new Carbon();
+        $carbon = Carbon::create(2018, 1, 1);
+
+        $this->assertFalse(
+            $carbon->getIndependenceDayHoliday()
+                ->isSameDay(Carbon::createFromDate(2018, 7, 3))
+        );
+
+        $this->assertTrue(
+            $carbon->getIndependenceDayHoliday()
+                ->isSameDay(Carbon::createFromDate(2018, 7, 4))
+        );
+    }
+
+    public function testLaborDay()
+    {
+        $carbon = new Carbon();
+        $carbon = Carbon::create(2018, 1, 1);
+
+        $this->assertFalse(
+            $carbon->getLaborDayHoliday()
+                ->isSameDay(Carbon::createFromDate(2018, 9, 4))
+        );
+
+        $this->assertTrue(
+            $carbon->getLaborDayHoliday()
+                ->isSameDay(Carbon::createFromDate(2018, 9, 3))
+        );
+    }
+
+    public function testPatriotsDay()
+    {
+        $carbon = new Carbon();
+        $carbon = Carbon::create(2018, 1, 1);
+
+        $this->assertFalse(
+            $carbon->getPatriotsDayHoliday()
+                ->isSameDay(Carbon::createFromDate(2018, 9, 10))
+        );
+
+        $this->assertTrue(
+            $carbon->getPatriotsDayHoliday()
+                ->isSameDay(Carbon::createFromDate(2018, 9, 11))
+        );
+    }
+
+    public function testColumbusDay()
+    {
+        $carbon = new Carbon();
+        $carbon = Carbon::create(2018, 1, 1);
+
+        $this->assertFalse(
+            $carbon->getColumbusDayHoliday()
+                ->isSameDay(Carbon::createFromDate(2018, 10, 10))
+        );
+
+        $this->assertTrue(
+            $carbon->getColumbusDayHoliday()
+                ->isSameDay(Carbon::createFromDate(2018, 10, 8))
+        );
+
+        $this->assertEquals('Christmas Day', Carbon::createFromDate(2010, 12, 25)->getHolidayName());
+    }
+
+    public function testIndigenousPeoplesDay()
+    {
+        $carbon = new Carbon();
+        $carbon = Carbon::create(2018, 1, 1);
+
+        $this->assertFalse(
+            $carbon->getIndigenousPeoplesDayHoliday()
+                ->isSameDay(Carbon::createFromDate(2018, 10, 10))
+        );
+
+        $this->assertTrue(
+            $carbon->getIndigenousPeoplesDayHoliday()
+                ->isSameDay(Carbon::createFromDate(2018, 10, 8))
+        );
+
+        $this->assertEquals("Columbus Day, Indigenous Peoples' Day", Carbon::createFromDate(2018, 10, 8)->getHolidayName());
+    }
+
+    public function testHalloweenDay()
+    {
+        $carbon = new Carbon();
+        $carbon = Carbon::create(2018, 1, 1);
+
+        $this->assertFalse(
+            $carbon->getHalloweenDayHoliday()
+                ->isSameDay(Carbon::createFromDate(2018, 10, 30))
+        );
+
+        $this->assertTrue(
+            $carbon->getHalloweenDayHoliday()
+                ->isSameDay(Carbon::createFromDate(2018, 10, 31))
+        );
+    }
+
+    public function testDaylightSavingEnd()
+    {
+        $carbon = new Carbon();
+        $carbon = Carbon::create(2018, 1, 1);
+
+        $this->assertFalse(
+            $carbon->getDaylightSavingEndHoliday()
+                ->isSameDay(Carbon::createFromDate(2018, 11, 3))
+        );
+
+        $this->assertTrue(
+            $carbon->getDaylightSavingEndHoliday()
+                ->isSameDay(Carbon::createFromDate(2018, 11, 4))
+        );
+    }
+
+    public function testVeteransDay()
+    {
+        $carbon = new Carbon();
+        $carbon = Carbon::create(2018, 1, 1);
+
+        $this->assertFalse(
+            $carbon->getVeteransDayHoliday()
+                ->isSameDay(Carbon::createFromDate(2018, 11, 10))
+        );
+
+        $this->assertTrue(
+            $carbon->getVeteransDayHoliday()
+                ->isSameDay(Carbon::createFromDate(2018, 11, 11))
+        );
+    }
+
     public function testThanksgiving()
     {
         $carbon = new Carbon();
@@ -21,19 +478,120 @@ class CarbonTest extends TestCase
         );
     }
 
-    public function testDayAfterThanksgiving()
+    public function testBlackFriday()
     {
         $carbon = new Carbon();
-        $carbon = Carbon::create(2019, 1, 1);
+        $carbon = Carbon::create(2018, 1, 1);
 
         $this->assertFalse(
-            $carbon->getDayAfterThanksgivingHoliday()
-                ->isSameDay(Carbon::createFromDate(2019, 11, 30))
+            $carbon->getBlackFridayHoliday()
+                ->isSameDay(Carbon::createFromDate(2018, 11, 24))
         );
 
         $this->assertTrue(
-            $carbon->getDayAfterThanksgivingHoliday()
-                ->isSameDay(Carbon::createFromDate(2019, 11, 29))
+            $carbon->getBlackFridayHoliday()
+                ->isSameDay(Carbon::createFromDate(2018, 11, 23))
+        );
+    }
+
+    public function testPearlHarborRemembrance()
+    {
+        $carbon = new Carbon();
+        $carbon = Carbon::create(2018, 1, 1);
+
+        $this->assertFalse(
+            $carbon->getPearlHarborRemembranceHoliday()
+                ->isSameDay(Carbon::createFromDate(2018, 12, 8))
+        );
+
+        $this->assertTrue(
+            $carbon->getPearlHarborRemembranceHoliday()
+                ->isSameDay(Carbon::createFromDate(2018, 12, 7))
+        );
+    }
+
+    public function testChristmasEve()
+    {
+        $carbon = new Carbon();
+        $carbon = Carbon::create(2018, 1, 1);
+
+        $this->assertFalse(
+            $carbon->getChristmasEveHoliday()
+                ->isSameDay(Carbon::createFromDate(2018, 12, 25))
+        );
+
+        $this->assertTrue(
+            $carbon->getChristmasEveHoliday()
+                ->isSameDay(Carbon::createFromDate(2018, 12, 24))
+        );
+    }
+
+    public function testChristmasDay()
+    {
+        $carbon = new Carbon();
+        $carbon = Carbon::create(2018, 1, 1);
+
+        $this->assertFalse(
+            $carbon->getChristmasDayHoliday()
+                ->isSameDay(Carbon::createFromDate(2018, 12, 26))
+        );
+
+        $this->assertTrue(
+            $carbon->getChristmasDayHoliday()
+                ->isSameDay(Carbon::createFromDate(2018, 12, 25))
+        );
+
+        $carbon = new Carbon();
+        $carbon = Carbon::create(2016, 1, 1);
+
+        $this->assertEquals('Christmas Day', Carbon::createFromDate(2016, 12, 25)->getHolidayName());
+        $this->assertEquals('Christmas Day (Observed), Kwanzaa', Carbon::createFromDate(2016, 12, 26)->getHolidayName());
+
+
+        $carbon = new Carbon();
+        $carbon = Carbon::create(2010, 1, 1);
+
+        $this->assertEquals('Christmas Day', Carbon::createFromDate(2010, 12, 25)->getHolidayName());
+        $this->assertEquals('Christmas Eve, Christmas Day (Observed)', Carbon::createFromDate(2010, 12, 24)->getHolidayName());
+    }
+
+    public function testKwanzaa()
+    {
+        $carbon = new Carbon();
+        $carbon = Carbon::create(2018, 1, 1);
+
+        $this->assertFalse(
+            $carbon->getKwanzaaHoliday()
+                ->isSameDay(Carbon::createFromDate(2018, 12, 24))
+        );
+
+        $this->assertTrue(
+            $carbon->getKwanzaaHoliday()
+                ->isSameDay(Carbon::createFromDate(2018, 12, 26))
+        );
+
+        $carbon = new Carbon();
+        $carbon = Carbon::create(2016, 1, 1);
+
+        $this->assertTrue(
+            $carbon->getKwanzaaHoliday()
+                ->isSameDay(Carbon::createFromDate(2016, 12, 26))
+        );
+    }
+
+    public function testNewYearsEve()
+    {
+        $carbon = new Carbon();
+        $carbon = Carbon::create(2018, 1, 1);
+
+        $this->assertFalse(
+            $carbon->getNewYearsEveHoliday()
+                ->isSameDay(Carbon::createFromDate(2018, 12, 30))
+        );
+
+        $this->assertTrue(
+            $carbon->getNewYearsEveHoliday()
+                ->isSameDay(Carbon::createFromDate(2018, 12, 31))
         );
     }
 }


### PR DESCRIPTION
Thank you for your work on this package! We're using it production at resonaterecordings.com. Last week we were writing custom code for Black Friday and we were chatting about the fact that many many businesses shut down for the Friday after Thanksgiving. So, here we are.

1. Added `phpunit` dev dependency and unit tests around Thanksgiving.
1. Removed tabs.
1. Added Contributing section to README with instructions for running the unit tests.
1. Added "Day After Thanksgiving" holiday and `getDayAfterThanksgivingHoliday` method.
1. Repair misspelling in the `getHoldiayById` method name.