### PR TITLE
PHP 8.4 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "require": {
         "nesbot/carbon": "^2.24.0|^3.0",
-        "php": "^7.4 || ^8.0",
+        "php": "^8.2",
         "ext-calendar": "*"
     },
     "autoload": {

--- a/src/USHolidays/Traits/Holiday.php
+++ b/src/USHolidays/Traits/Holiday.php
@@ -96,7 +96,7 @@ trait Holiday
      *
      * @param int|null $year The year to get the holidays in
      */
-    private function holidays(int $year = null)
+    private function holidays(?int $year = null)
     {
         $this->setTime(0, 0, 0);
         $holidays = [

--- a/src/USHolidays/Traits/Holidays/AprilFoolsDay.php
+++ b/src/USHolidays/Traits/Holidays/AprilFoolsDay.php
@@ -21,7 +21,7 @@ trait AprilFoolsDay
      *
      * @param int|null $year The year to get the holiday in
      */
-    public function getAprilFoolsDayHoliday(int $year = null)
+    public function getAprilFoolsDayHoliday(?int $year = null)
     {
         return $this->getHolidaysByYear("April Fools' Day", $year)[0];
     }

--- a/src/USHolidays/Traits/Holidays/ArmedForcesDay.php
+++ b/src/USHolidays/Traits/Holidays/ArmedForcesDay.php
@@ -28,7 +28,7 @@ trait ArmedForcesDay
      *
      * @param int|null $year The year to get the holiday in
      */
-    public function getArmedForcesDayHoliday(int $year = null)
+    public function getArmedForcesDayHoliday(?int $year = null)
     {
         return $this->getHolidaysByYear('Armed Forces Day', $year)[0];
     }

--- a/src/USHolidays/Traits/Holidays/AshWednesday.php
+++ b/src/USHolidays/Traits/Holidays/AshWednesday.php
@@ -19,7 +19,7 @@ trait AshWednesday
      *
      * @param int|null $year The year to get the holiday in
      */
-    public function getAshWednesdayHoliday(int $year = null)
+    public function getAshWednesdayHoliday(?int $year = null)
     {
         return $this->getHolidaysByYear('Ash Wednesday', $year)[0];
     }

--- a/src/USHolidays/Traits/Holidays/BlackFriday.php
+++ b/src/USHolidays/Traits/Holidays/BlackFriday.php
@@ -19,7 +19,7 @@ trait BlackFriday
      *
      * @param int|null $year The year to get the holiday in
      */
-    public function getBlackFridayHoliday(int $year = null)
+    public function getBlackFridayHoliday(?int $year = null)
     {
         return $this->getHolidaysByYear('Black Friday', $year)[0];
     }

--- a/src/USHolidays/Traits/Holidays/ChristmasDay.php
+++ b/src/USHolidays/Traits/Holidays/ChristmasDay.php
@@ -21,7 +21,7 @@ trait ChristmasDay
      *
      * @param int|null $year The year to get the holiday in
      */
-    public function getChristmasDayHoliday(int $year = null)
+    public function getChristmasDayHoliday(?int $year = null)
     {
         return $this->getHolidaysByYear('Christmas Day', $year)[0];
     }

--- a/src/USHolidays/Traits/Holidays/ChristmasEve.php
+++ b/src/USHolidays/Traits/Holidays/ChristmasEve.php
@@ -21,7 +21,7 @@ trait ChristmasEve
      *
      * @param int|null $year The year to get the holiday in
      */
-    public function getChristmasEveHoliday(int $year = null)
+    public function getChristmasEveHoliday(?int $year = null)
     {
         return $this->getHolidaysByYear('Christmas Eve', $year)[0];
     }

--- a/src/USHolidays/Traits/Holidays/CincoDeMayo.php
+++ b/src/USHolidays/Traits/Holidays/CincoDeMayo.php
@@ -21,7 +21,7 @@ trait CincoDeMayo
      *
      * @param int|null $year The year to get the holiday in
      */
-    public function getCincoDeMayoHoliday(int $year = null)
+    public function getCincoDeMayoHoliday(?int $year = null)
     {
         return $this->getHolidaysByYear('Cinco de Mayo', $year)[0];
     }

--- a/src/USHolidays/Traits/Holidays/ColumbusDay.php
+++ b/src/USHolidays/Traits/Holidays/ColumbusDay.php
@@ -28,7 +28,7 @@ trait ColumbusDay
      *
      * @param int|null $year The year to get the holiday in
      */
-    public function getColumbusDayHoliday(int $year = null)
+    public function getColumbusDayHoliday(?int $year = null)
     {
         return $this->getHolidaysByYear('Columbus Day', $year)[0];
     }

--- a/src/USHolidays/Traits/Holidays/CyberMonday.php
+++ b/src/USHolidays/Traits/Holidays/CyberMonday.php
@@ -19,7 +19,7 @@ trait CyberMonday
      *
      * @param int|null $year The year to get the holiday in
      */
-    public function getCyberMondayHoliday(int $year = null)
+    public function getCyberMondayHoliday(?int $year = null)
     {
         return $this->getHolidaysByYear('Cyber Monday', $year)[0];
     }

--- a/src/USHolidays/Traits/Holidays/DaylightSavingEnd.php
+++ b/src/USHolidays/Traits/Holidays/DaylightSavingEnd.php
@@ -27,7 +27,7 @@ trait DaylightSavingEnd
      *
      * @param int|null $year The year to get the holiday in
      */
-    public function getDaylightSavingEndHoliday(int $year = null)
+    public function getDaylightSavingEndHoliday(?int $year = null)
     {
         return $this->getHolidaysByYear('Daylight Saving (End)', $year)[0];
     }

--- a/src/USHolidays/Traits/Holidays/DaylightSavingStart.php
+++ b/src/USHolidays/Traits/Holidays/DaylightSavingStart.php
@@ -28,7 +28,7 @@ trait DaylightSavingStart
      *
      * @param int|null $year The year to get the holiday in
      */
-    public function getDaylightSavingStartHoliday(int $year = null)
+    public function getDaylightSavingStartHoliday(?int $year = null)
     {
         return $this->getHolidaysByYear('Daylight Saving (Start)', $year)[0];
     }

--- a/src/USHolidays/Traits/Holidays/EarthDay.php
+++ b/src/USHolidays/Traits/Holidays/EarthDay.php
@@ -21,7 +21,7 @@ trait EarthDay
      *
      * @param int|null $year The year to get the holiday in
      */
-    public function getEarthDayHoliday(int $year = null)
+    public function getEarthDayHoliday(?int $year = null)
     {
         return $this->getHolidaysByYear('Earth Day', $year)[0];
     }

--- a/src/USHolidays/Traits/Holidays/Easter.php
+++ b/src/USHolidays/Traits/Holidays/Easter.php
@@ -24,7 +24,7 @@ trait Easter
      *
      * @param int|null $year The year to get the holiday in
      */
-    public function getEasterHoliday(int $year = null)
+    public function getEasterHoliday(?int $year = null)
     {
         return $this->getHolidaysByYear('Easter', $year)[0];
     }

--- a/src/USHolidays/Traits/Holidays/FathersDay.php
+++ b/src/USHolidays/Traits/Holidays/FathersDay.php
@@ -28,7 +28,7 @@ trait FathersDay
      *
      * @param int|null $year The year to get the holiday in
      */
-    public function getFathersDayHoliday(int $year = null)
+    public function getFathersDayHoliday(?int $year = null)
     {
         return $this->getHolidaysByYear("Father's Day", $year)[0];
     }

--- a/src/USHolidays/Traits/Holidays/FlagDay.php
+++ b/src/USHolidays/Traits/Holidays/FlagDay.php
@@ -21,7 +21,7 @@ trait FlagDay
      *
      * @param int|null $year The year to get the holiday in
      */
-    public function getFlagDayHoliday(int $year = null)
+    public function getFlagDayHoliday(?int $year = null)
     {
         return $this->getHolidaysByYear('Flag Day', $year)[0];
     }

--- a/src/USHolidays/Traits/Holidays/GoodFriday.php
+++ b/src/USHolidays/Traits/Holidays/GoodFriday.php
@@ -19,7 +19,7 @@ trait GoodFriday
      *
      * @param int|null $year The year to get the holiday in
      */
-    public function getGoodFridayHoliday(int $year = null)
+    public function getGoodFridayHoliday(?int $year = null)
     {
         return $this->getHolidaysByYear('Good Friday', $year)[0];
     }

--- a/src/USHolidays/Traits/Holidays/GroundhogDay.php
+++ b/src/USHolidays/Traits/Holidays/GroundhogDay.php
@@ -21,7 +21,7 @@ trait GroundhogDay
      *
      * @param int|null $year The year to get the holiday in
      */
-    public function getGroundhogDayHoliday(int $year = null)
+    public function getGroundhogDayHoliday(?int $year = null)
     {
         return $this->getHolidaysByYear('Groundhog Day', $year)[0];
     }

--- a/src/USHolidays/Traits/Holidays/Halloween.php
+++ b/src/USHolidays/Traits/Holidays/Halloween.php
@@ -21,7 +21,7 @@ trait Halloween
      *
      * @param int|null $year The year to get the holiday in
      */
-    public function getHalloweenHoliday(int $year = null)
+    public function getHalloweenHoliday(?int $year = null)
     {
         return $this->getHolidaysByYear('Halloween', $year)[0];
     }

--- a/src/USHolidays/Traits/Holidays/Hanukkah.php
+++ b/src/USHolidays/Traits/Holidays/Hanukkah.php
@@ -21,7 +21,7 @@ trait Hanukkah
      *
      * @param int|null $year The year to get the holiday in
      */
-    public function getHanukkahHoliday(int $year = null)
+    public function getHanukkahHoliday(?int $year = null)
     {
         return $this->getHolidaysByYear('Hanukkah', $year)[0];
     }

--- a/src/USHolidays/Traits/Holidays/IndependenceDay.php
+++ b/src/USHolidays/Traits/Holidays/IndependenceDay.php
@@ -21,7 +21,7 @@ trait IndependenceDay
      *
      * @param int|null $year The year to get the holiday in
      */
-    public function getIndependenceDayHoliday(int $year = null)
+    public function getIndependenceDayHoliday(?int $year = null)
     {
         return $this->getHolidaysByYear('Independence Day', $year)[0];
     }

--- a/src/USHolidays/Traits/Holidays/IndigenousPeoplesDay.php
+++ b/src/USHolidays/Traits/Holidays/IndigenousPeoplesDay.php
@@ -19,7 +19,7 @@ trait IndigenousPeoplesDay
      *
      * @param int|null $year The year to get the holiday in
      */
-    public function getIndigenousPeoplesDayHoliday(int $year = null)
+    public function getIndigenousPeoplesDayHoliday(?int $year = null)
     {
         return $this->getHolidaysByYear("Indigenous Peoples' Day", $year)[0];
     }

--- a/src/USHolidays/Traits/Holidays/Juneteenth.php
+++ b/src/USHolidays/Traits/Holidays/Juneteenth.php
@@ -21,7 +21,7 @@ trait Juneteenth
      *
      * @param int|null $year The year to get the holiday in
      */
-    public function getJuneteenthHoliday(int $year = null)
+    public function getJuneteenthHoliday(?int $year = null)
     {
         return $this->getHolidaysByYear('Juneteenth', $year)[0];
     }

--- a/src/USHolidays/Traits/Holidays/Kwanzaa.php
+++ b/src/USHolidays/Traits/Holidays/Kwanzaa.php
@@ -21,7 +21,7 @@ trait Kwanzaa
      *
      * @param int|null $year The year to get the holiday in
      */
-    public function getKwanzaaHoliday(int $year = null)
+    public function getKwanzaaHoliday(?int $year = null)
     {
         return $this->getHolidaysByYear('Kwanzaa', $year)[0];
     }

--- a/src/USHolidays/Traits/Holidays/LaborDay.php
+++ b/src/USHolidays/Traits/Holidays/LaborDay.php
@@ -27,7 +27,7 @@ trait LaborDay
      *
      * @param int|null $year The year to get the holiday in
      */
-    public function getLaborDayHoliday(int $year = null)
+    public function getLaborDayHoliday(?int $year = null)
     {
         return $this->getHolidaysByYear('Labor Day', $year)[0];
     }

--- a/src/USHolidays/Traits/Holidays/MLKDay.php
+++ b/src/USHolidays/Traits/Holidays/MLKDay.php
@@ -28,7 +28,7 @@ trait MLKDay
      *
      * @param int|null $year The year to get the holiday in
      */
-    public function getMLKDayHoliday(int $year = null)
+    public function getMLKDayHoliday(?int $year = null)
     {
         return $this->getHolidaysByYear('Martin Luther King Jr. Day', $year)[0];
     }

--- a/src/USHolidays/Traits/Holidays/MemorialDay.php
+++ b/src/USHolidays/Traits/Holidays/MemorialDay.php
@@ -32,7 +32,7 @@ trait MemorialDay
      *
      * @param int|null $year The year to get the holiday in
      */
-    public function getMemorialDayHoliday(int $year = null)
+    public function getMemorialDayHoliday(?int $year = null)
     {
         return $this->getHolidaysByYear('Memorial Day', $year)[0];
     }

--- a/src/USHolidays/Traits/Holidays/MothersDay.php
+++ b/src/USHolidays/Traits/Holidays/MothersDay.php
@@ -28,7 +28,7 @@ trait MothersDay
      *
      * @param int|null $year The year to get the holiday in
      */
-    public function getMothersDayHoliday(int $year = null)
+    public function getMothersDayHoliday(?int $year = null)
     {
         return $this->getHolidaysByYear("Mother's Day", $year)[0];
     }

--- a/src/USHolidays/Traits/Holidays/NewYearsDay.php
+++ b/src/USHolidays/Traits/Holidays/NewYearsDay.php
@@ -21,7 +21,7 @@ trait NewYearsDay
      *
      * @param int|null $year The year to get the holiday in
      */
-    public function getNewYearsDayHoliday(int $year = null)
+    public function getNewYearsDayHoliday(?int $year = null)
     {
         return $this->getHolidaysByYear("New Year's Day", $year)[0];
     }

--- a/src/USHolidays/Traits/Holidays/NewYearsEve.php
+++ b/src/USHolidays/Traits/Holidays/NewYearsEve.php
@@ -21,7 +21,7 @@ trait NewYearsEve
      *
      * @param int|null $year The year to get the holiday in
      */
-    public function getNewYearsEveHoliday(int $year = null)
+    public function getNewYearsEveHoliday(?int $year = null)
     {
         return $this->getHolidaysByYear("New Year's Eve", $year)[0];
     }

--- a/src/USHolidays/Traits/Holidays/OrthodoxEaster.php
+++ b/src/USHolidays/Traits/Holidays/OrthodoxEaster.php
@@ -31,7 +31,7 @@ trait OrthodoxEaster
      *
      * @param int|null $year The year to get the holiday in
      */
-    public function getOrthodoxEasterHoliday(int $year = null)
+    public function getOrthodoxEasterHoliday(?int $year = null)
     {
         return $this->getHolidaysByYear('Orthodox Easter', $year)[0];
     }

--- a/src/USHolidays/Traits/Holidays/PalmSunday.php
+++ b/src/USHolidays/Traits/Holidays/PalmSunday.php
@@ -19,7 +19,7 @@ trait PalmSunday
      *
      * @param int|null $year The year to get the holiday in
      */
-    public function getPalmSundayHoliday(int $year = null)
+    public function getPalmSundayHoliday(?int $year = null)
     {
         return $this->getHolidaysByYear('Palm Sunday', $year)[0];
     }

--- a/src/USHolidays/Traits/Holidays/Passover.php
+++ b/src/USHolidays/Traits/Holidays/Passover.php
@@ -21,7 +21,7 @@ trait Passover
      *
      * @param int|null $year The year to get the holiday in
      */
-    public function getPassoverHoliday(int $year = null)
+    public function getPassoverHoliday(?int $year = null)
     {
         return $this->getHolidaysByYear('Passover', $year)[0];
     }

--- a/src/USHolidays/Traits/Holidays/PatriotsDay.php
+++ b/src/USHolidays/Traits/Holidays/PatriotsDay.php
@@ -21,7 +21,7 @@ trait PatriotsDay
      *
      * @param int|null $year The year to get the holiday in
      */
-    public function getPatriotDayHoliday(int $year = null)
+    public function getPatriotDayHoliday(?int $year = null)
     {
         return $this->getHolidaysByYear('Patriot Day', $year)[0];
     }

--- a/src/USHolidays/Traits/Holidays/PearlHarborRemembrance.php
+++ b/src/USHolidays/Traits/Holidays/PearlHarborRemembrance.php
@@ -21,7 +21,7 @@ trait PearlHarborRemembrance
      *
      * @param int|null $year The year to get the holiday in
      */
-    public function getPearlHarborRemembranceDayHoliday(int $year = null)
+    public function getPearlHarborRemembranceDayHoliday(?int $year = null)
     {
         return $this->getHolidaysByYear('Pearl Harbor Remembrance Day', $year)[0];
     }

--- a/src/USHolidays/Traits/Holidays/PresidentsDay.php
+++ b/src/USHolidays/Traits/Holidays/PresidentsDay.php
@@ -28,7 +28,7 @@ trait PresidentsDay
      *
      * @param int|null $year The year to get the holiday in
      */
-    public function getPresidentsDayHoliday(int $year = null)
+    public function getPresidentsDayHoliday(?int $year = null)
     {
         return $this->getHolidaysByYear("Presidents' Day", $year)[0];
     }

--- a/src/USHolidays/Traits/Holidays/RoshHashanah.php
+++ b/src/USHolidays/Traits/Holidays/RoshHashanah.php
@@ -21,7 +21,7 @@ trait RoshHashanah
      *
      * @param int|null $year The year to get the holiday in
      */
-    public function getRoshHashanahHoliday(int $year = null)
+    public function getRoshHashanahHoliday(?int $year = null)
     {
         return $this->getHolidaysByYear('Rosh Hashanah', $year)[0];
     }

--- a/src/USHolidays/Traits/Holidays/StPatricksDay.php
+++ b/src/USHolidays/Traits/Holidays/StPatricksDay.php
@@ -21,7 +21,7 @@ trait StPatricksDay
      *
      * @param int|null $year The year to get the holiday in
      */
-    public function getStPatricksDayHoliday(int $year = null)
+    public function getStPatricksDayHoliday(?int $year = null)
     {
         return $this->getHolidaysByYear("St. Patrick's Day", $year)[0];
     }

--- a/src/USHolidays/Traits/Holidays/TaxDay.php
+++ b/src/USHolidays/Traits/Holidays/TaxDay.php
@@ -29,7 +29,7 @@ trait TaxDay
      *
      * @param int|null $year The year to get the holiday in
      */
-    public function getTaxDayHoliday(int $year = null)
+    public function getTaxDayHoliday(?int $year = null)
     {
         return $this->getHolidaysByYear('Tax Day', $year)[0];
     }

--- a/src/USHolidays/Traits/Holidays/Thanksgiving.php
+++ b/src/USHolidays/Traits/Holidays/Thanksgiving.php
@@ -28,7 +28,7 @@ trait Thanksgiving
      *
      * @param int|null $year The year to get the holiday in
      */
-    public function getThanksgivingHoliday(int $year = null)
+    public function getThanksgivingHoliday(?int $year = null)
     {
         return $this->getHolidaysByYear('Thanksgiving', $year)[0];
     }

--- a/src/USHolidays/Traits/Holidays/ValentinesDay.php
+++ b/src/USHolidays/Traits/Holidays/ValentinesDay.php
@@ -21,7 +21,7 @@ trait ValentinesDay
      *
      * @param int|null $year The year to get the holiday in
      */
-    public function getValentinesDayHoliday(int $year = null)
+    public function getValentinesDayHoliday(?int $year = null)
     {
         return $this->getHolidaysByYear("Valentine's Day", $year)[0];
     }

--- a/src/USHolidays/Traits/Holidays/VeteransDay.php
+++ b/src/USHolidays/Traits/Holidays/VeteransDay.php
@@ -21,7 +21,7 @@ trait VeteransDay
      *
      * @param int|null $year The year to get the holiday in
      */
-    public function getVeteransDayHoliday(int $year = null)
+    public function getVeteransDayHoliday(?int $year = null)
     {
         return $this->getHolidaysByYear('Veterans Day', $year)[0];
     }

--- a/src/USHolidays/Traits/Holidays/YomKippur.php
+++ b/src/USHolidays/Traits/Holidays/YomKippur.php
@@ -21,7 +21,7 @@ trait YomKippur
      *
      * @param int|null $year The year to get the holiday in
      */
-    public function getYomKippurHoliday(int $year = null)
+    public function getYomKippurHoliday(?int $year = null)
     {
         return $this->getHolidaysByYear('Yom Kippur', $year)[0];
     }

--- a/src/USHolidays/USHolidays.php
+++ b/src/USHolidays/USHolidays.php
@@ -12,6 +12,7 @@ use USHolidays\Traits\Holiday;
 /**
  * This extends Carbon and adds support for 41 US holidays.
  */
+#[\AllowDynamicProperties]
 class USHolidays extends \Carbon\Carbon
 {
     use Holiday;

--- a/src/USHolidays/USHolidays.php
+++ b/src/USHolidays/USHolidays.php
@@ -80,7 +80,7 @@ class USHolidays extends \Carbon\Carbon
      * @param string|array $name The name(s) of the holidays to get
      * @param int|null $year The year to get the holidays in
      */
-    public function getHolidaysByYear($name = 'all', int $year = null): array
+    public function getHolidaysByYear($name = 'all', ?int $year = null): array
     {
         $this->shiftTimezone('UTC');
         $this->setTime(0, 0, 0);


### PR DESCRIPTION
Adds support for PHP 8.4. Prior to these changes, the following deprecations would be logged when accessing this package:
```
USHolidays\Traits\Holidays\YomKippur::getYomKippurHoliday(): Implicitly marking parameter $year as nullable is deprecated, the explicit nullable type must be used instead
Creation of dynamic property USHolidays\Carbon::$year is deprecated in /var/www/vendor/nesbot/carbon/src/Carbon/Traits/Date.php on line 1388  
```